### PR TITLE
Rename `primitives` to `core`

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-const { invoke } = window.__TAURI__.primitives;
+const { invoke } = window.__TAURI__.core;
 
 async function getVersion() {
   return invoke("plugin:app|version");

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,4 @@
-const { invoke } = window.__TAURI__.primitives;
+const { invoke } = window.__TAURI__.core;
 
 async function getMatches() {
   return await invoke("plugin:cli|cli_matches");

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -1,4 +1,4 @@
-const { invoke } = window.__TAURI__.primitives;
+const { invoke } = window.__TAURI__.core;
 
 async function writeText(text, opts) {
   return invoke("plugin:clipboard|write", {

--- a/src/dialog.js
+++ b/src/dialog.js
@@ -1,4 +1,4 @@
-const { invoke } = window.__TAURI__.primitives;
+const { invoke } = window.__TAURI__.core;
 
 async function open(options) {
   if (typeof options === "object") {

--- a/src/event.js
+++ b/src/event.js
@@ -1,4 +1,4 @@
-const { invoke, transformCallback } = window.__TAURI__.primitives;
+const { invoke, transformCallback } = window.__TAURI__.core;
 
 async function _unlisten(event, eventId) {
   await invoke("plugin:event|unlisten", {

--- a/src/fs.js
+++ b/src/fs.js
@@ -1,4 +1,4 @@
-const { invoke } = window.__TAURI__.primitives;
+const { invoke } = window.__TAURI__.core;
 
 async function readTextFile(filePath, options = {}) {
   return await invoke("plugin:fs|read_text_file", {

--- a/src/globalShortcut.js
+++ b/src/globalShortcut.js
@@ -1,4 +1,4 @@
-const { invoke, transformCallback } = window.__TAURI__.primitives;
+const { invoke, transformCallback } = window.__TAURI__.core;
 
 class Channel {
   id;

--- a/src/os.js
+++ b/src/os.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const invoke = window.__TAURI__.core.invoke;
 
 function eol() {
   return window.__TAURI__.os.__eol;

--- a/src/positioner.js
+++ b/src/positioner.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const invoke = window.__TAURI__.core.invoke;
 
 async function moveWindow(to) {
   await invoke("plugin:positioner|move_window", {

--- a/src/process.js
+++ b/src/process.js
@@ -1,4 +1,4 @@
-const invoke = window.__TAURI__.primitives.invoke;
+const invoke = window.__TAURI__.core.invoke;
 
 async function exit(code = 0) {
   return invoke("plugin:process|exit", { code });

--- a/src/store.js
+++ b/src/store.js
@@ -1,4 +1,4 @@
-const { invoke, transformCallback } = window.__TAURI__.primitives;
+const { invoke, transformCallback } = window.__TAURI__.core;
 
 async function _unlisten(event, eventId) {
   await invoke("plugin:event|unlisten", {

--- a/src/tauri.js
+++ b/src/tauri.js
@@ -1,5 +1,5 @@
-const convertFileSrc = window.__TAURI__.primitives.convertFileSrc;
-const invoke = window.__TAURI__.primitives.invoke;
-const transformCallback = window.__TAURI__.primitives.transformCallback;
+const convertFileSrc = window.__TAURI__.core.convertFileSrc;
+const invoke = window.__TAURI__.core.invoke;
+const transformCallback = window.__TAURI__.core.transformCallback;
 
 export { convertFileSrc, invoke, transformCallback };

--- a/src/updater.js
+++ b/src/updater.js
@@ -1,4 +1,4 @@
-const { invoke, transformCallback } = window.__TAURI__.primitives;
+const { invoke, transformCallback } = window.__TAURI__.core;
 
 class Channel {
   id;

--- a/src/window.js
+++ b/src/window.js
@@ -1,4 +1,4 @@
-const { invoke, transformCallback } = window.__TAURI__.primitives;
+const { invoke, transformCallback } = window.__TAURI__.core;
 
 // tauri/tooling/api/src/helpers/event.ts
 async function _unlisten(event, eventId) {


### PR DESCRIPTION
Since alpha 9, the `primitives` field of `__TAURI__` has been renamed to `core`. This simply reflects that change in the JS code.